### PR TITLE
Fix TypeError in roll_by_vector by ensuring all_idcs is mutable

### DIFF
--- a/glhmm/auxiliary.py
+++ b/glhmm/auxiliary.py
@@ -670,6 +670,9 @@ def roll_by_vector(arr, shifts, axis=1,gpu_enabled=False):
 
     arr = xp.swapaxes(arr,axis,-1)
     all_idcs = xp.ogrid[[slice(0,n) for n in arr.shape]]
+    # Check if all_idcs is a tuple, and convert to a list if needed
+    if isinstance(all_idcs, tuple): 
+        all_idcs = list(all_idcs)
 
     # Convert to a positive shift
     all_idcs[-1] = all_idcs[-1] - xp.expand_dims(shifts,axis=1)


### PR DESCRIPTION
Converted all_idcs to a list if it is a tuple to prevent assignment errors in roll_by_vector.