### PR TITLE
92 request for new preprocessing option

### DIFF
--- a/glhmm/glhmm.py
+++ b/glhmm/glhmm.py
@@ -460,7 +460,7 @@ class glhmm():
     def __check_Gamma(Gamma):
         K = Gamma.shape[1]
         if np.any(np.isnan(Gamma)):
-            raise Exception("NaN were generated in the state time courses, probably due to an artifacts") 
+            raise Exception("NaN were generated in the state time courses, probably due to a artifacts in the data. Consider using the preprocessing option 'dampen_extreme_peaks' before fitting the HMM ") 
         status = np.all(np.std(Gamma,axis=0)<0.001)
         #status = (np.max(Gamma)<0.6) and (np.min(Gamma)>(1/K/2))
         return status

--- a/glhmm/preproc.py
+++ b/glhmm/preproc.py
@@ -117,9 +117,9 @@ def dampen_peaks(X,strength=5):
     X_transformed : array-like of shape (n_samples, n_parcels)
         The transformed data after applying extreme peak dampening.
     """
-    x_mask = np.abs(X)>np.std(X)
+    x_mask = np.abs(X)>2*np.std(X)
     X_transformed = X.copy()
-    X_transformed[x_mask] = np.sign(X[x_mask])*(np.std(X) - np.log(np.std(X))/np.log(strength) + np.log(np.abs(X[x_mask]))/np.log(strength))
+    X_transformed[x_mask] = np.sign(X[x_mask])*(2*np.std(X) - np.log(2*np.std(X))/np.log(strength) + np.log(np.abs(X[x_mask]))/np.log(strength))
 
     return X_transformed
 


### PR DESCRIPTION
Added a new option for preprocessing data: dampen_extreme_peaks. this option is None by default. Can be set to True or to an integer value that indicates the strength of dampening. By default, is set to True, the strength of dampening will be 5 (i.e. setting the value of signal X to log_5(X) when abs(X)>2*(std(X)). 
If used, post_standardised becomes True and the data will be standardised after the dampening.
Added also a suggestion to use this preprocessing option if detected NaNs in Gammas during training.